### PR TITLE
Ability to select and upload multiple files from the explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
       },
       {
         "command": "push.upload",
-        "title": "Upload File",
+        "title": "Upload File(s)",
         "category": "Push",
         "icon": {
           "dark": "resources/dark/data-transfer-upload.svg",

--- a/src/UI.js
+++ b/src/UI.js
@@ -67,8 +67,29 @@ class UI extends Push {
 	/**
 	 * Uploads a single file or directory by its Uri.
 	 * @param {Uri} uri
+	 * @param {Uri} selectlist
 	 */
-	upload(uri) {
+	upload(uri, selectList) {
+		// According to https://code.visualstudio.com/updates/v1_6, a second parameter if provided, now contains a list of selected items.
+		// The active item still appears as the first item in the list. 
+		// Just to be safe, if there is no selectList, or there is only one uri, previous behavior preserved in the else block.
+		// It will also only add files to the list, will not add directories. No great reason other than I don't know the implications.
+		// Original author may be able to eliminate duplicate handling.
+		if (selectList != null && selectList.length > 1) {
+			let fileList = [];
+			for (var i = 0; i < selectList.length; i++) {
+				let uri = selectList[i];
+				if (uri && uri instanceof vscode.Uri) {
+					if (!this.paths.isDirectory(uri)) {
+						fileList.push(uri);
+					}
+				}
+			} // end for
+		  if (fileList.length > 0) {
+			return this.transfer(fileList, 'put');
+		  } else return Promise.reject();
+		} else {
+
 		if (!(uri = this.getValidUri(uri))) {
 			return Promise.reject();
 		}
@@ -80,8 +101,10 @@ class UI extends Push {
 		}
 
 		return this.transfer(uri, 'put').catch(this.catchError);
+		}
 	}
 
+	
 	/**
 	 * Downloads a single file or directory by its Uri.
 	 * @param {Uri} uri


### PR DESCRIPTION
Update to allow you to select and upload multiple files from the explorer. Does not support directories, skips them if you select a directory name. This leverages new functionality in Visual Studio Code which provides in an additional parameter to upload, a list of files selected. If one file is selected, the list will still only have the one file, but in this case I had it use the original method so the original author could review, and takes care of any edge cases from the previous method.